### PR TITLE
tweaked CI enforcement of coverage and style

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,6 @@ env:
   #   - TOXENV=docs
 matrix:
   include:
-    - python: '3.3'
-      env:
-        - TOXENV=py33,report,codecov
     - python: '3.4'
       env:
         - TOXENV=py34,report,codecov
@@ -27,13 +24,18 @@ before_install:
   - uname -a
   - lsb_release -a
 install:
-  - pip install tox diff_cover
+  - pip install -e .
+  - pip install tox diff_cover pytest pytest-cov flake8
   - virtualenv --version
   - easy_install --version
   - pip --version
   - tox --version
 script:
+  - git fetch origin master:refs/remotes/origin/master
   - tox -v
+  - pytest --cov-report=xml --cov=pepper
+  - diff-cover coverage.xml --compare-branch=origin/master --fail-under=100
+  - diff-quality --compare-branch=origin/master --violations=flake8 --fail-under=100
 after_failure:
   - more .tox/log/* | cat
   - more .tox/*/log/* | cat

--- a/tox.ini
+++ b/tox.ini
@@ -4,14 +4,13 @@
 envlist =
     clean,
     check,
-    {py33,py34,py35,py36,pypy},
+    {py34,py35,py36,pypy},
     report
     ; docs
 
 [testenv]
 basepython =
     pypy: {env:TOXPYTHON:pypy}
-    py33: {env:TOXPYTHON:python3.3}
     py34: {env:TOXPYTHON:python3.4}
     py35: {env:TOXPYTHON:python3.5}
     py36: {env:TOXPYTHON:python3.6}
@@ -79,10 +78,11 @@ commands =
 [testenv:codecov]
 deps =
     codecov
+    ; diff-cover
 skip_install = true
 commands =
     coverage xml --ignore-errors
-    diff-cover coverage.xml --compare-branch=origin/master --fail-under=100
+    ; diff-cover coverage.xml --compare-branch=master --fail-under=100
     codecov []
 
 


### PR DESCRIPTION
I fiddled with CI based enforcement of style and test coverage. in the process we dropped python 3.3 support, since pytest kind of choked on it.