### PR TITLE
Reparse expanded macros to see if there are more macros

### DIFF
--- a/src/pepper/preprocessor.py
+++ b/src/pepper/preprocessor.py
@@ -56,7 +56,8 @@ def main(args=None):
     while len(symtable.FILE_STACK):
         if symtable.EXPANDED_MACRO:
             symtable.EXPANDED_MACRO = False
-            parser_input = "\n" + preprocessed_lines[-2] + "\n"  # lexer eats the newlines, have to re-add them
+            # lexer eats the newlines, have to re-add them
+            parser_input = "\n" + preprocessed_lines[-2] + "\n"
             preprocessed_lines = preprocessed_lines[:-2]
         else:
             parser_input += symtable.FILE_STACK[-1].readline()

--- a/src/pepper/preprocessor.py
+++ b/src/pepper/preprocessor.py
@@ -54,13 +54,19 @@ def main(args=None):
     preprocessed_lines = [""]
 
     while len(symtable.FILE_STACK):
-        parser_input += symtable.FILE_STACK[-1].readline()
+        if symtable.EXPANDED_MACRO:
+            symtable.EXPANDED_MACRO = False
+            parser_input = "\n" + preprocessed_lines[-2] + "\n"  # lexer eats the newlines, have to re-add them
+            preprocessed_lines = preprocessed_lines[:-2]
+        else:
+            parser_input += symtable.FILE_STACK[-1].readline()
 
         if not len(parser_input):
             symtable.FILE_STACK.pop()
             if len(symtable.FILE_STACK):
                 preprocessed_lines.append("")
         elif not parser_input.endswith(r"\\n"):
+            print(f"Parsing '{parser_input}'")
             tree = parser.parse(parser_input)
             if len(symtable.IFDEF_STACK) == 0 or symtable.IFDEF_STACK[-1][1]:
                 output = tree.preprocess(preprocessed_lines)

--- a/src/pepper/symbol_table.py
+++ b/src/pepper/symbol_table.py
@@ -16,6 +16,7 @@ FILE_STACK = []
 IFDEF_STACK = []
 #: The list of paths to search when doing a system include
 SYSTEM_INCLUDE_PATHS = []
+EXPANDED_MACRO = False
 
 #: The default linux paths to search for includes-
 LINUX_DEFAULTS = [
@@ -49,6 +50,7 @@ class MacroExpansion():
         TABLE[self.name] = self
 
     def expand(self, args=None):
+        global EXPANDED_MACRO
         if self.args is None and args is not None:
             raise SyntaxError(f"Macro {self.name} doesn't take any args, but was given {len(args)}")
         elif self.args is not None and args is None:
@@ -61,6 +63,7 @@ class MacroExpansion():
                               f" expected {len(self.args)}, got {len(args)}")
 
         expansion = self.expansion
+        EXPANDED_MACRO = True
 
         if args:
             for index, arg in enumerate(args):

--- a/tests/preprocessor_test.py
+++ b/tests/preprocessor_test.py
@@ -83,3 +83,6 @@ class TestSystem:
 
     def test_comments(self, tmpdir):
         preprocess_and_compare('comments.cpp', 'comments.cpp.preprocessed.cc', tmpdir)
+
+    def test_nested_macro_expansion(self, tmpdir):
+        preprocess_and_compare('multiple_macros.cpp', 'multiple_macros.cpp.preprocessed.cc', tmpdir)

--- a/tests/test_data/multiple_macros.cpp
+++ b/tests/test_data/multiple_macros.cpp
@@ -1,0 +1,8 @@
+#define FINALMACRO "this is the last macro"
+#define SECONDMACRO std::cout << FINALMACRO << std::endl;
+#define FIRSTMACRO SECONDMACRO
+
+int main() {
+    std::cout << "We're going to expand some nested macros (oh no)" << std::endl;
+    FIRSTMACRO;
+}

--- a/tests/test_data/output_examples/multiple_macros.cpp.preprocessed.cc
+++ b/tests/test_data/output_examples/multiple_macros.cpp.preprocessed.cc
@@ -1,0 +1,6 @@
+// Macro FINALMACRO with args None expanding to '"this is the last macro"'
+
+int main() {
+    std::cout << "We're going to expand some nested macros (oh no)" << std::endl;
+    std::cout << "this is the last macro" << std::endl;;
+}


### PR DESCRIPTION
From the GNU C Preprocessor document:

> All arguments to a macro are completely macro-expanded before they are substituted into the macro body. After substitution, the complete text is scanned again for macros to expand, including the arguments. This rule may seem strange, but it is carefully designed so you need not worry about whether any function call is actually a macro invocation. 

We now re-scan expanded macro lines for moar macros, and expand them if found.

Addresses #25

## Change summary:

- added flag for if a macro was expanded in the last preprocessed chunk
- detect flag when ingesting raw source code--if flag set, use the last generated line instead of the next raw source line
- added test file to make sure nested macros get expanded