### PR TITLE
Cmi/error directive

### DIFF
--- a/src/pepper/abstract_symbol_tree.py
+++ b/src/pepper/abstract_symbol_tree.py
@@ -85,7 +85,7 @@ class PreprocessorErrorNode(Node):
         self.line_no = line_no
         self.file = file
 
-    def preprocess(self, lines: Optional[List[str]] = None) -> None:
+    def preprocess(self, lines: Optional[List[str]] = None) -> str:
         error_message = f"\n{self.file}:{self.line_no} error: " + cast(str, self.children[0])
         raise self.PepperCompileError(error_message)
 
@@ -96,12 +96,13 @@ class PreprocessorWarningNode(Node):
         self.line_no = line_no
         self.file = file
 
-    def preprocess(self, lines: Optional[List[str]] = None) -> None:
+    def preprocess(self, lines: Optional[List[str]] = None) -> str:
         relative = self.file.rfind("/")
         file_name = self.file if relative == -1 else self.file[relative + 1:]
 
         warning_message = f"\n{file_name}:{self.line_no} warning: " + cast(str, self.children[0])
         print(warning_message, file=stderr)
+        return ""  # statisfies typing
 
 class IdentifierNode(Node):
 

--- a/src/pepper/abstract_symbol_tree.py
+++ b/src/pepper/abstract_symbol_tree.py
@@ -86,24 +86,22 @@ class PreprocessorErrorNode(Node):
         self.file = file
 
     def preprocess(self, lines: Optional[List[str]] = None) -> None:
-        error_message = f"\n{self.file}:{self.line_no} error: " +  cast(str, self.children[0])
+        error_message = f"\n{self.file}:{self.line_no} error: " + cast(str, self.children[0])
         raise self.PepperCompileError(error_message)
 
 
 class PreprocessorWarningNode(Node):
-    def __init__(self, children: List[str] = [], line_no: int = 0, file : str = "") -> None:
+    def __init__(self, children: List[str] = [], line_no: int = 0, file: str = "") -> None:
         super(PreprocessorWarningNode, self).__init__("PreprocessorWarning", children)
         self.line_no = line_no
         self.file = file
 
     def preprocess(self, lines: Optional[List[str]] = None) -> None:
         relative = self.file.rfind("/")
-        file_name = self.file if relative == -1 else self.file[relative +1 :]
+        file_name = self.file if relative == -1 else self.file[relative + 1:]
 
         warning_message = f"\n{file_name}:{self.line_no} warning: " + cast(str, self.children[0])
-
-
-        print(warning_message, file = stderr)
+        print(warning_message, file=stderr)
 
 class IdentifierNode(Node):
 

--- a/src/pepper/abstract_symbol_tree.py
+++ b/src/pepper/abstract_symbol_tree.py
@@ -12,7 +12,7 @@ import pepper.symbol_table as symtable
 from pepper.symbol_table import Node
 import os
 from typing import List, Optional, cast
-
+from sys import stderr
 from pathlib import Path
 
 
@@ -97,9 +97,13 @@ class PreprocessorWarningNode(Node):
         self.file = file
 
     def preprocess(self, lines: Optional[List[str]] = None) -> None:
-        warning_message = f"\n{self.file}:{self.line_no} warning: " + cast(str, self.children[0])
-        print(warning_message)
+        relative = self.file.rfind("/")
+        file_name = self.file if relative == -1 else self.file[relative +1 :]
 
+        warning_message = f"\n{file_name}:{self.line_no} warning: " + cast(str, self.children[0])
+
+
+        print(warning_message, file = stderr)
 
 class IdentifierNode(Node):
 

--- a/src/pepper/abstract_symbol_tree.py
+++ b/src/pepper/abstract_symbol_tree.py
@@ -73,28 +73,31 @@ class PreprocessorIncludeNode(Node):
 
         return 'static_assert(0, "include node not properly implemented")'
 
+
 class PreprocessorErrorNode(Node):
 
     class PepperCompileError(Exception):
         def __init__(self, msg: str="") -> None:
             self.msg = msg
 
-    def __init__(self, children: List[Node] = [], line_no: int = 0) -> None:
+    def __init__(self, children: List[str] = [], line_no: int = 0, file: str = "") -> None:
         super(PreprocessorErrorNode, self).__init__("PreprocessorError", children)
         self.line_no = line_no
+        self.file = file
 
     def preprocess(self, lines: Optional[List[str]] = None) -> None:
-        error_message = f"{self.line_no} error: " + self.children[0].children[0]
+        error_message = f"\n{self.file}:{self.line_no} error: " +  cast(str, self.children[0])
         raise self.PepperCompileError(error_message)
 
 
 class PreprocessorWarningNode(Node):
-    def __init__(self, children: List[Node] = [], line_no: int = 0) -> None:
+    def __init__(self, children: List[str] = [], line_no: int = 0, file : str = "") -> None:
         super(PreprocessorWarningNode, self).__init__("PreprocessorWarning", children)
         self.line_no = line_no
+        self.file = file
 
     def preprocess(self, lines: Optional[List[str]] = None) -> None:
-        warning_message = f"{self.line_no} warning: " + self.children[0].children[0]
+        warning_message = f"\n{self.file}:{self.line_no} warning: " + cast(str, self.children[0])
         print(warning_message)
 
 

--- a/src/pepper/abstract_symbol_tree.py
+++ b/src/pepper/abstract_symbol_tree.py
@@ -73,6 +73,30 @@ class PreprocessorIncludeNode(Node):
 
         return 'static_assert(0, "include node not properly implemented")'
 
+class PreprocessorErrorNode(Node):
+
+    class PepperCompileError(Exception):
+        def __init__(self, msg: str="") -> None:
+            self.msg = msg
+
+    def __init__(self, children: List[Node] = [], line_no: int = 0) -> None:
+        super(PreprocessorErrorNode, self).__init__("PreprocessorError", children)
+        self.line_no = line_no
+
+    def preprocess(self, lines: Optional[List[str]] = None) -> None:
+        error_message = f"{self.line_no} error: " + self.children[0].children[0]
+        raise self.PepperCompileError(error_message)
+
+
+class PreprocessorWarningNode(Node):
+    def __init__(self, children: List[Node] = [], line_no: int = 0) -> None:
+        super(PreprocessorWarningNode, self).__init__("PreprocessorWarning", children)
+        self.line_no = line_no
+
+    def preprocess(self, lines: Optional[List[str]] = None) -> None:
+        warning_message = f"{self.line_no} warning: " + self.children[0].children[0]
+        print(warning_message)
+
 
 class IdentifierNode(Node):
 

--- a/src/pepper/lexer.py
+++ b/src/pepper/lexer.py
@@ -225,6 +225,7 @@ def t_comment_ignore_anything_else(t: lex.LexToken) -> lex.LexToken:
 def t_comment_NEWLINE(t: lex.LexToken) -> lex.LexToken:
     r'\n'
     t.lexer.lineno += 1  # the lexer doesn't know what consistutes a 'line' unless we tell it
+    symtable.LINE_COUNT += 1
     return t
 
 
@@ -237,6 +238,7 @@ def t_NEWLINE(t: lex.LexToken) -> lex.LexToken:
     r"\n"
     t.type = 'NEWLINE'
     t.lexer.lineno += 1  # the lexer doesn't know what consistutes a 'line' unless we tell it
+    symtable.LINE_COUNT += 1
     return t
 
 

--- a/src/pepper/lexer.py
+++ b/src/pepper/lexer.py
@@ -40,7 +40,8 @@ PREPROCESSING_KEYWORDS = [
     'else',
     'if',
     'py',
-    'error'
+    'error',
+    'warning'
 ]
 
 tokens = [
@@ -121,6 +122,11 @@ def t_PREPROCESSING_KEYWORD_DEFINE(t: lex.LexToken) -> lex.LexToken:
 
 def t_PREPROCESSING_KEYWORD_ERROR(t: lex.LexToken) -> lex.LexToken:
     r'\#error\b'
+    return t
+
+
+def t_PREPROCESSING_KEYWORD_WARNING(t: lex.LexToken) -> lex.LexToken:
+    r'\#warning\b'
     return t
 
 

--- a/src/pepper/lexer.py
+++ b/src/pepper/lexer.py
@@ -40,6 +40,7 @@ PREPROCESSING_KEYWORDS = [
     'else',
     'if',
     'py',
+    'error'
 ]
 
 tokens = [
@@ -115,6 +116,11 @@ def t_PREPROCESSING_KEYWORD_INCLUDE(t: lex.LexToken) -> lex.LexToken:
 
 def t_PREPROCESSING_KEYWORD_DEFINE(t: lex.LexToken) -> lex.LexToken:
     r'\#define\b'
+    return t
+
+
+def t_PREPROCESSING_KEYWORD_ERROR(t: lex.LexToken) -> lex.LexToken:
+    r'\#error\b'
     return t
 
 

--- a/src/pepper/parser.py
+++ b/src/pepper/parser.py
@@ -86,6 +86,8 @@ def p_statement_to_code_expression(p: yacc.YaccProduction) -> yacc.YaccProductio
 def p_pepper_directive(p: yacc.YaccProduction) -> yacc.YaccProduction:
     """
     pepper_directive : preprocessor_expression
+                     | error_directive
+                     | warning_directive
     """
     p[0] = p[1]
 
@@ -717,6 +719,18 @@ def p_statement_to_char(p: yacc.YaccProduction) -> yacc.YaccProduction:
     """
     p[0] = ast.StringLiteralNode([p[1]])
 
+
+def p_error_directive(p: yacc.YaccProduction) ->yacc.YaccProduction:
+    """
+    error_directive : PREPROCESSING_KEYWORD_ERROR spaces STRING_LITERAL
+    """
+    p[0] = ast.PreprocessorErrorNode([ast.StringLiteralNode([p[3]])], str(p.lineno))
+
+def p_warning_directive(p: yacc.YaccProduction) ->yacc.YaccProduction:
+    """
+    warning_directive : PREPROCESSING_KEYWORD_WARNING spaces STRING_LITERAL
+    """
+    p[0] = ast.PreprocessorWarningNode([ast.StringLiteralNode([p[3]])], p.lineno)
 
 def p_error(p: yacc.YaccProduction) -> yacc.YaccProduction:
     print(f"ERROR(line {p.lineno}): syntax error")

--- a/src/pepper/parser.py
+++ b/src/pepper/parser.py
@@ -724,13 +724,15 @@ def p_error_directive(p: yacc.YaccProduction) ->yacc.YaccProduction:
     """
     error_directive : PREPROCESSING_KEYWORD_ERROR spaces STRING_LITERAL
     """
-    p[0] = ast.PreprocessorErrorNode([ast.StringLiteralNode([p[3]])], str(p.lineno))
+    p[0] = ast.PreprocessorErrorNode( [p[3]], symtable.LINE_COUNT, symtable.FILE_STACK[-1].name)
+
 
 def p_warning_directive(p: yacc.YaccProduction) ->yacc.YaccProduction:
     """
     warning_directive : PREPROCESSING_KEYWORD_WARNING spaces STRING_LITERAL
     """
-    p[0] = ast.PreprocessorWarningNode([ast.StringLiteralNode([p[3]])], p.lineno)
+    p[0] = ast.PreprocessorWarningNode([p[3]], symtable.LINE_COUNT, symtable.FILE_STACK[-1].name)
+
 
 def p_error(p: yacc.YaccProduction) -> yacc.YaccProduction:
     print(f"ERROR(line {p.lineno}): syntax error")

--- a/src/pepper/parser.py
+++ b/src/pepper/parser.py
@@ -389,7 +389,7 @@ def p_if_expression(p: yacc.YaccProduction) -> yacc.YaccProduction:
     """
     symtable.IF_COUNT += 1
 
-    symtable.IF_STACK.append((str(symtable.IF_COUNT), True))
+    symtable.IF_STACK.append((str(symtable.IF_COUNT), p[3]))
     p[0] = ast.StringLiteralNode([f"// if expression result: { int(p[3]) }"])
 
 

--- a/src/pepper/preprocessor.py
+++ b/src/pepper/preprocessor.py
@@ -16,6 +16,7 @@ import os
 import pepper.symbol_table as symtable
 from pathlib import Path
 from typing import Optional
+import pepper.abstract_symbol_tree as ast
 
 def get_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser()
@@ -86,14 +87,18 @@ def main(args: Optional[argparse.Namespace]=None) -> None:
                 print(f"{parser_input}")
                 raise err
             if len(symtable.IF_STACK) == 0 or symtable.IF_STACK[-1][1]:
-                #try:
-                output = tree.preprocess(preprocessed_lines)
-                #except Exception as err:
-                #    print("An internal error occured while processing a line:")
-                #    print(f"{parser_input}")
-                #    print("Please report this error: https://github.com/devosoft/Pepper/issues")
-                #    print(f"{err}")
-                #    raise symtable.PepperInternalError()
+                try:
+                    output = tree.preprocess(preprocessed_lines)
+                except ast.PreprocessorErrorNode.PepperCompileError as compile_err:
+                    # store stack trace
+                    # stack_trace = sys.exc_info()
+                    raise compile_err
+                except Exception as err:
+                    print("An internal error occured while processing a line:")
+                    print(f"{parser_input}")
+                    print("Please report this error: https://github.com/devosoft/Pepper/issues")
+                    print(f"{err}")
+                    raise symtable.PepperInternalError()
             else:
                 pass  # toss the line, we're in a 'deny' ifdef
             parser_input = ""

--- a/src/pepper/preprocessor.py
+++ b/src/pepper/preprocessor.py
@@ -16,7 +16,7 @@ import os
 import pepper.symbol_table as symtable
 from pathlib import Path
 from typing import Optional
-
+from pepper.abstract_symbol_tree import PreprocessorErrorNode
 
 def get_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser()
@@ -87,14 +87,14 @@ def main(args: Optional[argparse.Namespace]=None) -> None:
                 print(f"{parser_input}")
                 raise err
             if len(symtable.IF_STACK) == 0 or symtable.IF_STACK[-1][1]:
-                try:
-                    output = tree.preprocess(preprocessed_lines)
-                except Exception as err:
-                    print("An internal error occured while processing a line:")
-                    print(f"{parser_input}")
-                    print("Please report this error: https://github.com/devosoft/Pepper/issues")
-                    print(f"{err}")
-                    raise symtable.PepperInternalError()
+                #try:
+                output = tree.preprocess(preprocessed_lines)
+                #except Exception as err:
+                #    print("An internal error occured while processing a line:")
+                #    print(f"{parser_input}")
+                #    print("Please report this error: https://github.com/devosoft/Pepper/issues")
+                #    print(f"{err}")
+                #    raise symtable.PepperInternalError()
             else:
                 pass  # toss the line, we're in a 'deny' ifdef
             parser_input = ""

--- a/src/pepper/preprocessor.py
+++ b/src/pepper/preprocessor.py
@@ -16,7 +16,6 @@ import os
 import pepper.symbol_table as symtable
 from pathlib import Path
 from typing import Optional
-from pepper.abstract_symbol_tree import PreprocessorErrorNode
 
 def get_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser()

--- a/src/pepper/symbol_table.py
+++ b/src/pepper/symbol_table.py
@@ -29,7 +29,8 @@ EXPANDED_MACRO = False
 TRIGGER_INTERNAL_ERROR = False
 #: Count of if directive calls
 IF_COUNT = 0
-
+#: Global Line Count
+LINE_COUNT = 0
 def build_default_include_lists() -> List[str]:
     p = subprocess.run(["cpp", "-v", "/dev/null", "-o", "/dev/null"],
                        stdout=subprocess.PIPE,

--- a/tests/preprocessor_test.py
+++ b/tests/preprocessor_test.py
@@ -329,7 +329,8 @@ class TestUnit:
             with open(f"{test_dir.realpath()}/{source}.preprocessed.cc") as outfile:
                 assert(outfile.read() == expected_file.read())
 
-        assert(process.stderr == b'\nwarning.cpp:4 warning: "WARNING"\n\nwarning.cpp:8 warning: "WARNING"\n')
+        assert(process.stderr ==
+               b'\nwarning.cpp:4 warning: "WARN"\n\nwarning.cpp:8 warning: "WARN"\n')
 
     def test_warning_directive_not_raised(self, tmpdir):
         preprocess_and_compare("no_warning.cpp", "no_warning.cpp.preprocessed.cc",

--- a/tests/preprocessor_test.py
+++ b/tests/preprocessor_test.py
@@ -97,7 +97,6 @@ def preprocess_and_compare(source, reference, tmpdir, supportfiles=[], optional_
     call = ["Pepper"] + optional_args + [f"{test_dir.realpath()}/{source}"]
 
     process = subprocess.run(call, timeout=2, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    #out, err = process.communicate()
     assert(process.returncode == 0)
     with open(f'{EXAMPLE_OUTPUT_DIRECTORY}{reference}', 'r') as expected_file:
         with open(f"{test_dir.realpath()}/{source}.preprocessed.cc") as outfile:
@@ -322,17 +321,15 @@ class TestUnit:
         reference = source + ".preprocessed.cc"
         shutil.copy(SOURCE_FILE_DIRECTORY + source, test_dir.realpath())
 
-
         call = ["Pepper"] + [f"{test_dir.realpath()}/{source}"]
-
         process = subprocess.run(call, timeout=2, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-
         assert(process.returncode == 0)
+
         with open(f'{EXAMPLE_OUTPUT_DIRECTORY}{reference}', 'r') as expected_file:
             with open(f"{test_dir.realpath()}/{source}.preprocessed.cc") as outfile:
                 assert(outfile.read() == expected_file.read())
 
-        assert(process.stderr == b'\nwarning.cpp:4 warning: "This warning should appear"\n')
+        assert(process.stderr == b'\nwarning.cpp:4 warning: "WARNING"\n\nwarning.cpp:8 warning: "WARNING"\n')
 
     def test_warning_directive_not_raised(self, tmpdir):
         preprocess_and_compare("no_warning.cpp", "no_warning.cpp.preprocessed.cc",

--- a/tests/preprocessor_test.py
+++ b/tests/preprocessor_test.py
@@ -96,13 +96,14 @@ def preprocess_and_compare(source, reference, tmpdir, supportfiles=[], optional_
 
     call = ["Pepper"] + optional_args + [f"{test_dir.realpath()}/{source}"]
 
-    process = subprocess.run(call, timeout=2, stdout=sys.stdout, stderr=sys.stderr)
-    # out, err = process.communicate()
+    process = subprocess.run(call, timeout=2, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    #out, err = process.communicate()
     assert(process.returncode == 0)
     with open(f'{EXAMPLE_OUTPUT_DIRECTORY}{reference}', 'r') as expected_file:
         with open(f"{test_dir.realpath()}/{source}.preprocessed.cc") as outfile:
             assert(outfile.read() == expected_file.read())
 
+    assert(not process.stderr)
 
 class TestUnit:
     def setup_method(self, method):
@@ -277,6 +278,65 @@ class TestUnit:
 
         assert(exception_raised)
 
+    def test_error_directive_raised(self, tmpdir):
+        in_contents = [
+            "#ifndef __M1__\n",
+            '#error "This constant should be present!"\n',
+            "#endif"
+        ]
+
+        expected = [""]
+
+        args = FakeArgs()
+        args.input_file = FakeFile("macro_error.cc", in_contents)
+        expected_file = FakeFile("whatever", expected)
+
+        exception_raised = False
+        try:
+            # doesn't actually matter what the reference is
+            preprocess_and_compare_functionally(None, expected_file, args)
+            assert(False and "Should have had an exception thrown!")
+        except ast.PreprocessorErrorNode.PepperCompileError as err:
+            exception_raised = True
+
+        assert(exception_raised)
+
+    def test_error_directive_not_raised(self, tmpdir):
+        in_contents = [
+            "#ifdef __M1__\n",
+            '#error "This constant shouldnt be present!"\n',
+            "#endif"
+        ]
+
+        expected = ["// endif expression ", ""]
+
+        args = FakeArgs()
+        args.input_file = FakeFile("macro_error.cc", in_contents)
+        expected_file = FakeFile("whatever", expected)
+
+        preprocess_and_compare_functionally(None, expected_file, args)
+
+    def test_warning_directive_raised(self, tmpdir):
+        test_dir = tmpdir.mkdir('preprocessor')
+        source = "warning.cpp"
+        reference = source + ".preprocessed.cc"
+        shutil.copy(SOURCE_FILE_DIRECTORY + source, test_dir.realpath())
+
+
+        call = ["Pepper"] + [f"{test_dir.realpath()}/{source}"]
+
+        process = subprocess.run(call, timeout=2, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+        assert(process.returncode == 0)
+        with open(f'{EXAMPLE_OUTPUT_DIRECTORY}{reference}', 'r') as expected_file:
+            with open(f"{test_dir.realpath()}/{source}.preprocessed.cc") as outfile:
+                assert(outfile.read() == expected_file.read())
+
+        assert(process.stderr == b'\nwarning.cpp:4 warning: "This warning should appear"\n')
+
+    def test_warning_directive_not_raised(self, tmpdir):
+        preprocess_and_compare("no_warning.cpp", "no_warning.cpp.preprocessed.cc",
+                               tmpdir)
 
 
 class TestSystem:

--- a/tests/test_data/no_warning.cpp
+++ b/tests/test_data/no_warning.cpp
@@ -1,0 +1,11 @@
+#ifdef __M__
+#warning "This warning shouldn't appear"
+#endif
+
+
+int main()
+{
+
+    return 0;
+}
+

--- a/tests/test_data/no_warning.cpp
+++ b/tests/test_data/no_warning.cpp
@@ -2,6 +2,9 @@
 #warning "This warning shouldn't appear"
 #endif
 
+#if defined __M__
+#warning "This warning shouldn't appear"
+#endif
 
 int main()
 {

--- a/tests/test_data/output_examples/no_warning.cpp.preprocessed.cc
+++ b/tests/test_data/output_examples/no_warning.cpp.preprocessed.cc
@@ -1,5 +1,6 @@
 // endif expression 
 
+// endif expression 
 
 int main()
 {

--- a/tests/test_data/output_examples/no_warning.cpp.preprocessed.cc
+++ b/tests/test_data/output_examples/no_warning.cpp.preprocessed.cc
@@ -1,0 +1,10 @@
+// endif expression 
+
+
+int main()
+{
+
+    return 0;
+}
+
+

--- a/tests/test_data/output_examples/warning.cpp.preprocessed.cc
+++ b/tests/test_data/output_examples/warning.cpp.preprocessed.cc
@@ -1,0 +1,12 @@
+// Macro __M__ with args None expanding to '0'
+
+// if expression result: 1
+
+// endif expression 
+
+
+int main()
+{
+
+    return 0;
+}

--- a/tests/test_data/output_examples/warning.cpp.preprocessed.cc
+++ b/tests/test_data/output_examples/warning.cpp.preprocessed.cc
@@ -4,6 +4,9 @@
 
 // endif expression 
 
+// ifdef expression __M__
+
+// endif expression 
 
 int main()
 {

--- a/tests/test_data/warning.cpp
+++ b/tests/test_data/warning.cpp
@@ -1,0 +1,12 @@
+#define __M__ 0
+
+#if defined(__M__) || defined(__X__)
+#warning "This warning should appear"
+#endif
+
+
+int main()
+{
+
+    return 0;
+}

--- a/tests/test_data/warning.cpp
+++ b/tests/test_data/warning.cpp
@@ -1,11 +1,11 @@
 #define __M__ 0
 
 #if defined(__M__) || defined(__X__)
-#warning "WARNING"
+#warning "WARN"
 #endif
 
 #ifdef __M__
-#warning "WARNING"
+#warning "WARN"
 #endif
 
 int main()

--- a/tests/test_data/warning.cpp
+++ b/tests/test_data/warning.cpp
@@ -1,9 +1,12 @@
 #define __M__ 0
 
 #if defined(__M__) || defined(__X__)
-#warning "This warning should appear"
+#warning "WARNING"
 #endif
 
+#ifdef __M__
+#warning "WARNING"
+#endif
 
 int main()
 {


### PR DESCRIPTION
error & warning directive 
created error and warning nodes that get preprocessed, signaling that they should execute
if warning, message gets sent to stderr, 
if error it raises a exception called `PepperCompileError`, since "technically" its supposed to invoke a compile time error. 
